### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,14 @@
+FROM gitpod/workspace-full
+
+
+RUN sudo apt-get update -q \
+    && sudo apt-get install -y php-dev
+
+RUN wget http://xdebug.org/files/xdebug-2.9.1.tgz \
+    && tar -xvzf xdebug-2.9.1.tgz \
+    && cd xdebug-2.9.1 \
+    && phpize \
+    && ./configure \
+    && make \
+    && sudo cp modules/xdebug.so /usr/lib/php/20170718 \
+    && sudo bash -c "echo -e '\nzend_extension = /usr/lib/php/20170718/xdebug.so\n[XDebug]\nxdebug.remote_enable = 1\nxdebug.remote_autostart = 1\n' >> /etc/php/7.2/cli/php.ini"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,2 @@
-tasks:
-  - init: echo "Replace me with a build script for the project."
-    command: echo "Replace me with something that should run on every start, or just
-      remove me entirely."
+image:
+  file: .gitpod.Dockerfile


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.